### PR TITLE
feat(console): add displayLimit for terminal log rendering

### DIFF
--- a/docs/features/CONSOLE_INTERCEPTION_GUIDE.md
+++ b/docs/features/CONSOLE_INTERCEPTION_GUIDE.md
@@ -105,6 +105,29 @@ console.log("Database connected");
 
 - **`onlyUserApp`**: Acts as a "Strict Mode" visual filter. When enabled, **only** logs natively categorized as `[USERAPP]` by the Go engine (matched via the `userAppPatterns` regex) will be rendered to the terminal. Other core classifications such as `[SYSTEM]` will still be fully intercepted and available to background Hooks, but they are visually hidden to keep your `stdout` focused purely on application-level events.
 
+- **`displayLimit`**: Limits the number of log lines rendered in the terminal. Inspired by the Linux `head` and `tail` commands. Operates purely in the TypeScript layer after XHSC processing — all logs are still fully intercepted and delegated to hooks.
+
+    | Property   | Type                 | Default  | Description                        |
+    | ---------- | -------------------- | -------- | ---------------------------------- |
+    | `mode`     | `"head"` \| `"tail"` | `"tail"` | Limiting strategy                  |
+    | `maxLines` | `number`             | —        | Maximum number of lines to display |
+
+    **`head` mode** (`mode: "head"`) — Only the first N logs are rendered to the terminal after startup. Subsequent logs are silently intercepted in the background but never printed. Equivalent to `head -n N`.
+
+    ```typescript
+    // Show only the first 20 logs at startup
+    displayLimit: { mode: "head", maxLines: 20 }
+    ```
+
+    **`tail` mode** (`mode: "tail"`, default) — Maintains a live circular buffer of the last N logs. On each new log, the oldest entry is evicted and the terminal is redrawn to always show the most recent N lines. Equivalent to `tail -n N -f`. Only active in TTY environments; in non-TTY (CI/pipes), logs print sequentially.
+
+    ```typescript
+    // Always show only the last 10 logs
+    displayLimit: { mode: "tail", maxLines: 10 }
+    ```
+
+    > **Note**: `displayLimit` only controls terminal rendering. All logs still flow through the XHSC engine and are available via `onLog` hooks and internal plugin hooks regardless of this setting.
+
 ## Advanced Technical Features
 
 ### Cryptographic Log Protection

--- a/simulations/XCIS/src/server.ts
+++ b/simulations/XCIS/src/server.ts
@@ -4,21 +4,31 @@ const app = createServer({
     logging: {
         consoleInterception: {
             enabled: true,
-            interceptMethods: ["log", "warn", "error", "info", "debug", "trace"],
+            interceptMethods: [
+                "log",
+                "warn",
+                "error",
+                "info",
+                "debug",
+                "trace",
+            ],
             preserveOriginal: {
                 enabled: true,
                 mode: "intercepted",
-                showPrefix: false, 
+                showPrefix: false,
                 separateStreams: true,
                 allowDuplication: false,
                 onlyUserApp: false,
                 customPrefix: "[XCIS]",
                 colorize: true,
+                // Display limit: behaves like `tail -n 15 -f` in the terminal
+                displayLimit: { mode: "head", maxLines: 3 },
             },
             performanceMode: true,
             maxInterceptionsPerSecond: 1000,
+
             onLog: (log) => {
-                // console.log("Log intercepted by onLog callback:", log);
+                console.log("Log intercepted by onLog callback:", log);
                 __sys__.fs.appendLineSync("onLog.log", JSON.stringify(log));
             },
             sourceMapping: true,
@@ -45,7 +55,4 @@ setTimeout(() => {
         // process.stdout.write("Tracing output\n");
     }, 600);
 }, 2000);
-
-
-
 

--- a/src/server/components/fastapi/console/ConsoleInterceptor.ts
+++ b/src/server/components/fastapi/console/ConsoleInterceptor.ts
@@ -34,6 +34,10 @@ export class ConsoleInterceptor {
     private storage = new AsyncLocalStorage<boolean>();
     private hasSyncedConfig = false;
     private recentRawMessages: string[] = [];
+    /** Counter for head mode: how many lines have been displayed so far */
+    private displayLineCount = 0;
+    /** Circular buffer for tail mode: holds the last N processed lines */
+    private displayTailBuffer: string[] = [];
 
     public static getInstance(logger: Logger): ConsoleInterceptor {
         if (!ConsoleInterceptor.instance) {
@@ -69,6 +73,64 @@ export class ConsoleInterceptor {
             isActive: false,
         };
         this.ipcPath = process.env.XYPRISS_IPC_PATH;
+    }
+
+    /**
+     * Decides whether a log line should be displayed given the current displayLimit config.
+     * In `head` mode, only the first N lines are allowed through.
+     * In `tail` mode, lines are always buffered; the buffer is printed on each new log.
+     *
+     * @returns true  when the line should be printed immediately (head/no-limit),
+     *          false when suppressed (head limit reached) or deferred (tail, handled internally).
+     */
+    private shouldAllowDisplay(
+        finalMsg: string,
+        preserve: any,
+        targetConsole: ((...a: any[]) => void) | undefined,
+    ): boolean {
+        const limit =
+            preserve && typeof preserve === "object"
+                ? (preserve as any).displayLimit
+                : undefined;
+
+        if (!limit || !limit.maxLines) {
+            // No limit configured — always allow
+            return true;
+        }
+
+        const mode: "head" | "tail" = limit.mode || "tail";
+        const max: number = limit.maxLines;
+
+        if (mode === "head") {
+            if (this.displayLineCount >= max) {
+                // Suppress: head limit already reached
+                return false;
+            }
+            this.displayLineCount++;
+            return true;
+        }
+
+        // tail mode: maintain a circular buffer and reprint
+        if (this.displayTailBuffer.length >= max) {
+            this.displayTailBuffer.shift();
+        }
+        this.displayTailBuffer.push(finalMsg);
+
+        // Clear terminal lines equal to current buffer length, then reprint
+        if (process.stdout.isTTY) {
+            // Move cursor up by buffer length - 1 (the new entry is not yet printed)
+            const linesToClear = this.displayTailBuffer.length - 1;
+            if (linesToClear > 0) {
+                process.stdout.write(`\x1b[${linesToClear}A\x1b[0J`);
+            }
+            this.displayTailBuffer.forEach((line) => targetConsole?.(line));
+        } else {
+            // Non-TTY (piped output, CI): just print the line normally
+            return true;
+        }
+
+        // Already printed internally — skip the outer targetConsole call
+        return false;
     }
 
     public async start(): Promise<void> {
@@ -326,7 +388,14 @@ export class ConsoleInterceptor {
                                 );
                             }
 
-                            targetConsole?.(finalMsg);
+                            const allowed = this.shouldAllowDisplay(
+                                finalMsg,
+                                preserve,
+                                targetConsole,
+                            );
+                            if (allowed) {
+                                targetConsole?.(finalMsg);
+                            }
                         }
                     }
 

--- a/src/server/components/fastapi/console/types.ts
+++ b/src/server/components/fastapi/console/types.ts
@@ -58,6 +58,23 @@ export interface ConsoleInterceptionConfig {
               allowDuplication?: boolean;
               separateStreams?: boolean;
               onlyUserApp?: boolean;
+              /**
+               * Limit the number of log lines displayed in the terminal.
+               * Inspired by the Linux `head`/`tail` commands.
+               *
+               * - `head`: display only the first N logs then stop (like `head -n N`).
+               * - `tail`: always keep the last N logs visible in memory;
+               *           each new log evicts the oldest (circular buffer).
+               *
+               * @example
+               * displayLimit: { mode: "tail", maxLines: 50 }
+               */
+              displayLimit?: {
+                  /** Limiting strategy. Defaults to "tail". */
+                  mode?: "head" | "tail";
+                  /** Maximum number of log lines to display. */
+                  maxLines: number;
+              };
           };
 }
 


### PR DESCRIPTION
Introduce displayLimit configuration to control the number of log lines shown in the terminal, inspired by Linux head and tail commands. Supports "head" mode to display only the first N logs and "tail" mode for a live circular buffer of the last N logs. Updates include type definitions, implementation in ConsoleInterceptor with TTY handling, simulation config, and documentation.

BREAKING CHANGE: displayLimit config now affects terminal output visibility, potentially altering user experience in environments with high log volume.
