### PR TITLE
fix(xems): resolve session persistence and config propagation issues (closes #28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xypriss",
-  "version": "9.12.11",
+  "version": "9.12.12",
   "description": "XyPriss is a high-performance, TypeScript-first hyper-system web framework powered by a native Go core (XHSC), featuring robust multi-tenant sandboxing, secure native file streaming, and zero Express dependencies.",
   "author": {
     "DEV.to": "https://dev.to/nehonix",

--- a/src/middleware/XemsSessionMiddleware.ts
+++ b/src/middleware/XemsSessionMiddleware.ts
@@ -101,6 +101,7 @@ export function xemsSession(options: XemsTypes) {
                     sandbox,
                     rotate: autoRotation,
                     ttl,
+                    gracePeriod: options.gracePeriod,
                 });
 
                 if (session) {

--- a/src/middleware/XemsSessionMiddleware.ts
+++ b/src/middleware/XemsSessionMiddleware.ts
@@ -107,7 +107,7 @@ export function xemsSession(options: XemsTypes) {
                     // Attach data to request
                     (req as any)[attachTo] = session.data;
 
-                    if (autoRotation && session.newToken) {
+                    if (session.newToken) {
                         // Store new token for response injection
                         (res as any)._xemsNewToken = session.newToken;
 

--- a/src/plugins/builtin/xems/XemsBuiltinPlugin.ts
+++ b/src/plugins/builtin/xems/XemsBuiltinPlugin.ts
@@ -303,7 +303,12 @@ export class XemsBuiltinPlugin implements XyPrissPlugin {
         // 3. Session Recovery & Rotation
         if (token && this.hasValidSecret) {
             try {
-                const session = await this.runner.from(sandbox).rotate(token, {
+                // Use resolveSession with rotate=autoRotation.
+                // When autoRotation=false, the token is read without being invalidated,
+                // so the browser cookie remains valid on subsequent requests.
+                const session = await this.runner.resolveSession(token, {
+                    sandbox,
+                    rotate: autoRotation,
                     ttl,
                     gracePeriod: this.sessionOptions.gracePeriod,
                 });
@@ -311,10 +316,11 @@ export class XemsBuiltinPlugin implements XyPrissPlugin {
                 if (session) {
                     (req as any)[attachTo] = session.data;
 
-                    if (autoRotation && session.newToken) {
+                    // If a new token was issued (rotation happened), inject it into the
+                    // response so the browser cookie stays in sync.
+                    if (session.newToken) {
                         (res as any)._xemsNewToken = session.newToken;
 
-                        // Intercept response methods to inject the rotated token
                         const originalSend = res.send;
                         res.send = function (this: any, body: any) {
                             const newToken = (res as any)._xemsNewToken;

--- a/src/server/FastServer/index.ts
+++ b/src/server/FastServer/index.ts
@@ -16,8 +16,6 @@ import { WorkerPoolComponent } from "../components/fastapi/WorkerPoolComponent";
 import { FileUploadManager } from "../components/fastapi/upload/FileUploadManager";
 import { ConsoleInterceptor } from "../components/fastapi/console/ConsoleInterceptor";
 import { SecurityMiddleware } from "../../middleware/security-middleware";
-import { xemsSession } from "../../middleware/XemsSessionMiddleware";
-import { DEFAULT_OPTIONS } from "../const/default";
 
 import { MiddlewareManager } from "./MiddlewareManager";
 import { ShutdownManager } from "./ShutdownManager";
@@ -219,14 +217,10 @@ export class XyPrissServer {
                 this.logger,
             );
             this.app.use(this.securityMiddleware.getMiddleware());
-            if (this.options.server?.xems?.enable) {
-                this.app.use(
-                    xemsSession(
-                        this.options.server?.xems ||
-                            DEFAULT_OPTIONS?.server?.xems!,
-                    ),
-                );
-            }
+            // NOTE: XEMS session handling is done exclusively by XemsBuiltinPlugin.onRequest()
+            // which is registered via the plugin manager. Running xemsSession() here in parallel
+            // would cause a double resolveSession() — the first call may invalidate the token
+            // (if autoRotation=true) before the second can read it.
         }
     }
 


### PR DESCRIPTION
## Context

Fixes issue #28: XEMS session cookie options not applied correctly, and session becoming undefined after page refresh.

## Root causes identified

### 1. [Critical] Token invalidated after first request (session lost on refresh)
The plugin's `onRequest()` called `.rotate()` which **always** sent `rotate: true` to the Rust binary, regardless of the `autoRotation` flag. On the first post-login request, the old token was invalidated and a new one was generated — but since `autoRotation: false`, the new token was never injected into the browser cookie. Every subsequent request sent the now-invalid old token, resulting in `req.session = undefined`.

### 2. [Critical] Double XEMS handler per request
`FastServer.initializeSecurity()` registered `xemsSession()` as Express middleware **and** `XemsBuiltinPlugin.onRequest()` was registered separately via the plugin manager. Both ran on every request, both called `resolveSession()` on the same token. With `autoRotation: true`, the first handler invalidates the token before the second can read it — guaranteed session loss.

### 3. [Minor] `gracePeriod` not forwarded in `XemsSessionMiddleware`
The configured `gracePeriod` was never passed to `resolveSession()`, falling back to the runner's hardcoded 1000ms default.

## Changes

| File | Change |
|------|--------|
| `XemsBuiltinPlugin.ts` | Use `resolveSession(rotate: autoRotation)` instead of `rotate()` (always true) |
| `XemsBuiltinPlugin.ts` | Inject new token into cookie whenever `session.newToken` exists (not gated on `autoRotation`) |
| `XemsSessionMiddleware.ts` | Same cookie injection fix |
| `XemsSessionMiddleware.ts` | Forward `gracePeriod` to `resolveSession()` |
| `FastServer/index.ts` | Remove redundant `xemsSession()` middleware — session handled exclusively by the plugin |